### PR TITLE
ConvertToGematriaNumericString with separator is wrong for single chars (10,20,30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ obj
 /Gematria.v11.suo
 /Gematria.sln.DotSettings.user
 *.nupkg
-/.vs/Gematria/v16

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ obj
 /Gematria.v11.suo
 /Gematria.sln.DotSettings.user
 *.nupkg
+/.vs/Gematria/v16

--- a/EllisWeb.Gematria.Tests/Calculator_Tests.cs
+++ b/EllisWeb.Gematria.Tests/Calculator_Tests.cs
@@ -183,7 +183,7 @@ namespace EllisWeb.Gematria.Tests
 
         public void ConvertToGematriaNumericString_SingleDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() {IncludeSeparators = false});
             Assert.AreEqual(expected, output);
         }
 
@@ -194,7 +194,7 @@ namespace EllisWeb.Gematria.Tests
         [TestCase(100, "ק")]
         public void ConvertToGematriaNumericString_TwoDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false });
             Assert.AreEqual(expected, output);
         }
 
@@ -206,7 +206,7 @@ namespace EllisWeb.Gematria.Tests
         [TestCase(100, @"ק""")]
         public void ConvertToGematriaNumericString_AnyDigitAmount_WithSeparators_WithDoubleQoute_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(addQuoteAfterSingleChar:false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { AddQuoteAfterSingleChar = false});
             Assert.AreEqual(expected, output);
         }
 
@@ -236,7 +236,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 15;
             string expected = "טו";
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false });
             Assert.AreEqual(expected, output);
         }
 
@@ -254,7 +254,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 16;
             string expected = "טז";
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false)); 
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false }); 
             Assert.AreEqual(expected, output);
         }
 
@@ -263,7 +263,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 245;
             string expected = "רמה";
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false });
             Assert.AreEqual(expected, output);
         }
 
@@ -281,7 +281,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 5767;
             string expected = "התשסז";
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false });
             Assert.AreEqual(expected, output);
         }
 
@@ -299,7 +299,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 1024999;
             string expected = "אכדתתקצט";
-            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions() { IncludeSeparators = false });
             Assert.AreEqual(expected, output);
         }
 

--- a/EllisWeb.Gematria.Tests/Calculator_Tests.cs
+++ b/EllisWeb.Gematria.Tests/Calculator_Tests.cs
@@ -178,29 +178,32 @@ namespace EllisWeb.Gematria.Tests
             Calculator.ConvertToGematriaNumericString(input);
         }
 
-        [Test]
-        public void ConvertToGematriaNumericString_SingleDigit_NoSeparators_ReturnsCorrectString()
+        [TestCase(5,"ה")]
+        [TestCase(9,"ט")]
+
+        public void ConvertToGematriaNumericString_SingleDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            int input = 5;
-            string expected = "ה";
             string output = Calculator.ConvertToGematriaNumericString(input, false);
             Assert.AreEqual(expected, output);
         }
 
-        [Test]
-        public void ConvertToGematriaNumericString_TwoDigit_NoSeparators_ReturnsCorrectString()
+        [TestCase(10, "י")]
+        [TestCase(12, "יב")]
+        [TestCase(20, "כ")]
+        [TestCase(30, "ל")]
+        public void ConvertToGematriaNumericString_TwoDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            int input = 12;
-            string expected = "יב";
             string output = Calculator.ConvertToGematriaNumericString(input, false);
             Assert.AreEqual(expected, output);
         }
 
-        [Test]
-        public void ConvertToGematriaNumericString_TwoDigit_WithSeparators_ReturnsCorrectString()
+        [TestCase(10, @"י'")]
+        [TestCase(11, @"י""א")]
+        [TestCase(12, @"י""ב")]
+        [TestCase(20, @"כ'")]
+        [TestCase(30, @"ל'")]
+        public void ConvertToGematriaNumericString_TwoDigit_WithSeparators_ReturnsCorrectString(int input, string expected)
         {
-            int input = 12;
-            string expected = "י\"ב";
             string output = Calculator.ConvertToGematriaNumericString(input);
             Assert.AreEqual(expected, output);
         }

--- a/EllisWeb.Gematria.Tests/Calculator_Tests.cs
+++ b/EllisWeb.Gematria.Tests/Calculator_Tests.cs
@@ -166,7 +166,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 0;
             string expected = string.Empty;
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -175,7 +175,7 @@ namespace EllisWeb.Gematria.Tests
         public void ConvertToGematriaNumericString_NegativeNumber_ThrowsException()
         {
             int input = -1;
-            Calculator.ConvertToGematriaNumericString(input);
+            Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
         }
 
         [TestCase(5,"ה")]
@@ -183,7 +183,7 @@ namespace EllisWeb.Gematria.Tests
 
         public void ConvertToGematriaNumericString_SingleDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
             Assert.AreEqual(expected, output);
         }
 
@@ -191,9 +191,22 @@ namespace EllisWeb.Gematria.Tests
         [TestCase(12, "יב")]
         [TestCase(20, "כ")]
         [TestCase(30, "ל")]
+        [TestCase(100, "ק")]
         public void ConvertToGematriaNumericString_TwoDigit_NoSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
+            Assert.AreEqual(expected, output);
+        }
+
+        [TestCase(1, @"א""")]
+        [TestCase(3, @"ג""")]
+        [TestCase(6, @"ו""")]
+        [TestCase(9, @"ט""")]
+        [TestCase(12, @"י""ב")]
+        [TestCase(100, @"ק""")]
+        public void ConvertToGematriaNumericString_AnyDigitAmount_WithSeparators_WithDoubleQoute_ReturnsCorrectString(int input, string expected)
+        {
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(addQuoteAfterSingleChar:false));
             Assert.AreEqual(expected, output);
         }
 
@@ -203,7 +216,7 @@ namespace EllisWeb.Gematria.Tests
         [TestCase(9, @"ט'")]
         public void ConvertToGematriaNumericString_SingleDigit_WithSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -214,7 +227,7 @@ namespace EllisWeb.Gematria.Tests
         [TestCase(30, @"ל'")]
         public void ConvertToGematriaNumericString_TwoDigit_WithSeparators_ReturnsCorrectString(int input, string expected)
         {
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -223,7 +236,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 15;
             string expected = "טו";
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
             Assert.AreEqual(expected, output);
         }
 
@@ -232,7 +245,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 15;
             string expected = "ט\"ו";
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -241,7 +254,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 16;
             string expected = "טז";
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false)); 
             Assert.AreEqual(expected, output);
         }
 
@@ -250,7 +263,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 245;
             string expected = "רמה";
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
             Assert.AreEqual(expected, output);
         }
 
@@ -259,7 +272,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 613;
             string expected = "תרי\"ג";
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -268,7 +281,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 5767;
             string expected = "התשסז";
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
             Assert.AreEqual(expected, output);
         }
 
@@ -277,7 +290,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 5767;
             string expected = "ה'תשס\"ז";
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions());
             Assert.AreEqual(expected, output);
         }
 
@@ -286,7 +299,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 1024999;
             string expected = "אכדתתקצט";
-            string output = Calculator.ConvertToGematriaNumericString(input, false);
+            string output = Calculator.ConvertToGematriaNumericString(input, new GematriaOptions(false));
             Assert.AreEqual(expected, output);
         }
 
@@ -295,7 +308,7 @@ namespace EllisWeb.Gematria.Tests
         {
             int input = 1024999;
             string expected = "א'כד'תתקצ\"ט";
-            string output = Calculator.ConvertToGematriaNumericString(input);
+            string output = Calculator.ConvertToGematriaNumericString(input,new GematriaOptions()); 
             Assert.AreEqual(expected, output);
         }
 

--- a/EllisWeb.Gematria.Tests/Calculator_Tests.cs
+++ b/EllisWeb.Gematria.Tests/Calculator_Tests.cs
@@ -197,6 +197,16 @@ namespace EllisWeb.Gematria.Tests
             Assert.AreEqual(expected, output);
         }
 
+        [TestCase(1, @"א'")]
+        [TestCase(3, @"ג'")]
+        [TestCase(6, @"ו'")]
+        [TestCase(9, @"ט'")]
+        public void ConvertToGematriaNumericString_SingleDigit_WithSeparators_ReturnsCorrectString(int input, string expected)
+        {
+            string output = Calculator.ConvertToGematriaNumericString(input);
+            Assert.AreEqual(expected, output);
+        }
+
         [TestCase(10, @"י'")]
         [TestCase(11, @"י""א")]
         [TestCase(12, @"י""ב")]

--- a/EllisWeb.Gematria/Calculator.cs
+++ b/EllisWeb.Gematria/Calculator.cs
@@ -84,7 +84,7 @@ namespace EllisWeb.Gematria
                 {
                     return KnownNumericValues[stripped];
                 }
-            } 
+            }
 
             if (Regex.IsMatch(sourceString, @"[\s]"))
             {
@@ -141,7 +141,7 @@ namespace EllisWeb.Gematria
                     }
                 }
                 var stackMultiplier = Math.Pow(1000, currentStackIndex++);
-                var adjustedStackSum = Convert.ToInt64(stackSum*stackMultiplier);
+                var adjustedStackSum = Convert.ToInt64(stackSum * stackMultiplier);
                 value += adjustedStackSum;
             }
 
@@ -172,7 +172,8 @@ namespace EllisWeb.Gematria
             if (number == 0)
             {
                 return string.Empty;
-            } else if (number < 0)
+            }
+            else if (number < 0)
             {
                 throw new ArgumentException("Number is less than zero", "number");
             }
@@ -205,21 +206,28 @@ namespace EllisWeb.Gematria
             }
 
             // If needed, add in final quotation separator between tens and singles letter
-            if (includeSeparators && originalNumber >= 10)
+            if (includeSeparators)
             {
-                if (str.Length == 1)
+                if (originalNumber < 10)
                 {
-                    // for specific cases (single char when separator is required), we use the thousands separator - AFTER the character...
+                    // for single character we use the thousands separator - AFTER the character...
                     str.Append(thousandsSeparator);
                 }
-                else if (str.Length > 1)
+                else if (originalNumber >= 10)
                 {
-                    // add in a quotation separator between the second-to-last and last characters
-                    str.Insert(str.Length - 1, tensSeparator);
+                    if (str.Length == 1)
+                    {
+                        // for specific cases (single char when separator is required), we use the thousands separator - AFTER the character...
+                        str.Append(thousandsSeparator);
+                    }
+                    else if (str.Length > 1)
+                    {
+                        // add in a quotation separator between the second-to-last and last characters
+                        str.Insert(str.Length - 1, tensSeparator);
+                    }
                 }
-              
             }
-            
+
             return str.ToString();
         }
 
@@ -240,7 +248,7 @@ namespace EllisWeb.Gematria
             var valueList = dict.Select(x => x.Value).ToList(); // get list of all available values
             valueList.Sort();
             valueList.Reverse(); // get value list in reverse order - highest number first. Speeds up evaluations.
-            
+
             StringBuilder str = new StringBuilder();
             while (number > 0)
             {
@@ -249,7 +257,7 @@ namespace EllisWeb.Gematria
                 {
                     str.Append("טו");
                     break;
-                } 
+                }
                 if (number == 16)
                 {
                     str.Append("טז");

--- a/EllisWeb.Gematria/Calculator.cs
+++ b/EllisWeb.Gematria/Calculator.cs
@@ -152,6 +152,30 @@ namespace EllisWeb.Gematria
         /// Convert a number into its Gematria Numeric representation
         /// </summary>
         /// <param name="number">The non-negative number to evaluate</param>
+        /// <param name="includeSeparators">Should separators between thousands-groupings be included in the string that is returned</param>
+        /// <param name="thousandsSeparator">Value to use separating between thousands-groupings. Defaults to a single quote (')</param>
+        /// <param name="tensSeparator">Value to use separating between the tens and single digit letters. Defaults to a double quote (")</param>
+        /// <example>
+        /// 8 ==> ח
+        /// 15 ==> ט"ו
+        /// 245 ==> רמ"ה
+        /// 5,767 ==> ה'תשס"ז
+        /// 1,024,999 ==> א'כד'תתרצ"ט
+        /// </example>
+        /// <remarks>
+        /// Will evaluate each thousands-grouping separately, inserting separators if needed.
+        /// A value of 15 will always be represented as ט"ו and 16 will be represented as ט"ז, following Jewish custom. 
+        /// </remarks>
+        /// <returns>Gemtria Numeric representation of given number</returns>
+        public static string ConvertToGematriaNumericString(long number, bool includeSeparators = true, char thousandsSeparator = '\'', char tensSeparator = '"')
+        {
+            return ConvertToGematriaNumericString(number, new GematriaOptions(includeSeparators, thousandsSeparator, tensSeparator));
+        }
+
+        /// <summary>
+        /// Convert a number into its Gematria Numeric representation
+        /// </summary>
+        /// <param name="number">The non-negative number to evaluate</param>
         /// <param name="options">Gematria conversion options</param>
         /// <example>
         /// 8 ==> ח

--- a/EllisWeb.Gematria/Calculator.cs
+++ b/EllisWeb.Gematria/Calculator.cs
@@ -150,6 +150,7 @@ namespace EllisWeb.Gematria
 
         /// <summary>
         /// Convert a number into its Gematria Numeric representation
+        /// this method is only a wrapper for the other overload which utilizes <see cref="GematriaOptions"/> class.
         /// </summary>
         /// <param name="number">The non-negative number to evaluate</param>
         /// <param name="includeSeparators">Should separators between thousands-groupings be included in the string that is returned</param>
@@ -167,9 +168,14 @@ namespace EllisWeb.Gematria
         /// A value of 15 will always be represented as ט"ו and 16 will be represented as ט"ז, following Jewish custom. 
         /// </remarks>
         /// <returns>Gemtria Numeric representation of given number</returns>
+        [Obsolete("Please use the other overload - ConvertToGematriaNumericString with GematriaOptions")]
         public static string ConvertToGematriaNumericString(long number, bool includeSeparators = true, char thousandsSeparator = '\'', char tensSeparator = '"')
         {
-            return ConvertToGematriaNumericString(number, new GematriaOptions(includeSeparators, thousandsSeparator, tensSeparator));
+            return ConvertToGematriaNumericString(number, new GematriaOptions(){ 
+                IncludeSeparators = includeSeparators,
+                ThousandsSeparator = thousandsSeparator,
+                TensSeparator = tensSeparator
+            });
         }
 
         /// <summary>

--- a/EllisWeb.Gematria/Calculator.cs
+++ b/EllisWeb.Gematria/Calculator.cs
@@ -184,8 +184,8 @@ namespace EllisWeb.Gematria
             {
                 int currentGrouping = Convert.ToInt32(number % 1000);
                 numberGroupings.Add(currentGrouping);
-                number = number - currentGrouping;
-                number = number / 1000;
+                number -= currentGrouping;
+                number /= 1000;
             }
 
             // Number groupings now have the smallest groupings (0-999) first, and the largest groupings last. 
@@ -207,8 +207,17 @@ namespace EllisWeb.Gematria
             // If needed, add in final quotation separator between tens and singles letter
             if (includeSeparators && originalNumber >= 10)
             {
-                // add in a quotation separator between the second-to-last and last characters
-                str.Insert(str.Length - 1, tensSeparator);
+                if (str.Length == 1)
+                {
+                    // for specific cases (single char when separator is required), we use the thousands separator - AFTER the character...
+                    str.Append(thousandsSeparator);
+                }
+                else if (str.Length > 1)
+                {
+                    // add in a quotation separator between the second-to-last and last characters
+                    str.Insert(str.Length - 1, tensSeparator);
+                }
+              
             }
             
             return str.ToString();

--- a/EllisWeb.Gematria/EllisWeb.Gematria.csproj
+++ b/EllisWeb.Gematria/EllisWeb.Gematria.csproj
@@ -49,6 +49,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Calculator.cs" />
+    <Compile Include="GematriaOptions.cs" />
     <Compile Include="GematriaType.cs" />
     <Compile Include="LookupFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/EllisWeb.Gematria/GematriaOptions.cs
+++ b/EllisWeb.Gematria/GematriaOptions.cs
@@ -28,23 +28,23 @@
         /// <summary>
         /// Should separators between thousands-groupings be included in the string that is returned
         /// </summary>
-        public bool IncludeSeparators { get; }
+        public bool IncludeSeparators { get; } = DEFAULT_SHOULD_INCLUDE_SEPARATORS;
 
         /// <summary>
         /// Value to use separating between thousands-groupings. Defaults to a single quote (')
         /// </summary>
-        public char ThousandsSeparator { get; }
+        public char ThousandsSeparator { get; } = DEFAULT_THOUSANDS_SEPARATOR;
 
         /// <summary>
         /// Value to use separating between the tens and single digit letters. Defaults to a double quote (")
         /// </summary>
-        public char TensSeparator { get; }
+        public char TensSeparator { get; } = DEFAULT_TENS_SEPARATOR;
 
         /// <summary>
         /// <para>When the result is a single char, Should we place a single quote (true) or a double-quote (false)</para>
         /// <para>The default is true - adding a single quote</para>
         /// </summary>
-        public bool AddQuoteAfterSingleChar { get; }
+        public bool AddQuoteAfterSingleChar { get; } = DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR;
 
         /// <summary>
         /// new instance of options to convert a number into its Gematria representation

--- a/EllisWeb.Gematria/GematriaOptions.cs
+++ b/EllisWeb.Gematria/GematriaOptions.cs
@@ -6,62 +6,24 @@
     public class GematriaOptions
     {
         /// <summary>
-        /// default value for <see cref="IncludeSeparators"/>
-        /// </summary>
-        public const bool DEFAULT_SHOULD_INCLUDE_SEPARATORS = true;
-
-        /// <summary>
-        /// default value for <see cref="ThousandsSeparator"/>
-        /// </summary>
-        public const char DEFAULT_THOUSANDS_SEPARATOR = '\'';
-
-        /// <summary>
-        /// default value for <see cref="TensSeparator"/>
-        /// </summary>
-        public const char DEFAULT_TENS_SEPARATOR = '"';
-
-        /// <summary>
-        /// default value for <see cref="AddQuoteAfterSingleChar"/>
-        /// </summary>
-        public const bool DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR = true;
-
-        /// <summary>
         /// Should separators between thousands-groupings be included in the string that is returned
         /// </summary>
-        public bool IncludeSeparators { get; } = DEFAULT_SHOULD_INCLUDE_SEPARATORS;
+        public bool IncludeSeparators { get; set; } = true;
 
         /// <summary>
         /// Value to use separating between thousands-groupings. Defaults to a single quote (')
         /// </summary>
-        public char ThousandsSeparator { get; } = DEFAULT_THOUSANDS_SEPARATOR;
+        public char ThousandsSeparator { get; set; } = '\'';
 
         /// <summary>
         /// Value to use separating between the tens and single digit letters. Defaults to a double quote (")
         /// </summary>
-        public char TensSeparator { get; } = DEFAULT_TENS_SEPARATOR;
+        public char TensSeparator { get; set; } = '"';
 
         /// <summary>
         /// <para>When the result is a single char, Should we place a single quote (true) or a double-quote (false)</para>
         /// <para>The default is true - adding a single quote</para>
         /// </summary>
-        public bool AddQuoteAfterSingleChar { get; } = DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR;
-
-        /// <summary>
-        /// new instance of options to convert a number into its Gematria representation
-        /// </summary>
-        /// <param name="includeSeparators">Should separators between thousands-groupings be included in the string that is returned</param>
-        /// <param name="thousandsSeparator">Value to use separating between thousands-groupings. Defaults to a single quote (')</param>
-        /// <param name="tensSeparator">Value to use separating between the tens and single digit letters. Defaults to a double quote (")</param>
-        /// <param name="addQuoteAfterSingleChar">When the result is a single char, Should we place a single quote (true) or a double-quote (false)</param>
-        public GematriaOptions(bool includeSeparators = DEFAULT_SHOULD_INCLUDE_SEPARATORS,
-            char thousandsSeparator = DEFAULT_THOUSANDS_SEPARATOR,
-            char tensSeparator = DEFAULT_TENS_SEPARATOR,
-            bool addQuoteAfterSingleChar = DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR)
-        {
-            IncludeSeparators = includeSeparators;
-            ThousandsSeparator = thousandsSeparator;
-            TensSeparator = tensSeparator;
-            AddQuoteAfterSingleChar = addQuoteAfterSingleChar;
-        }
+        public bool AddQuoteAfterSingleChar { get; set; } = true;
     }
 }

--- a/EllisWeb.Gematria/GematriaOptions.cs
+++ b/EllisWeb.Gematria/GematriaOptions.cs
@@ -1,0 +1,67 @@
+﻿namespace EllisWeb.Gematria
+{
+    /// <summary>
+    /// Options when converting a number into its Gematria representation
+    /// </summary>
+    public class GematriaOptions
+    {
+        /// <summary>
+        /// default value for <see cref="IncludeSeparators"/>
+        /// </summary>
+        public const bool DEFAULT_SHOULD_INCLUDE_SEPARATORS = true;
+
+        /// <summary>
+        /// default value for <see cref="ThousandsSeparator"/>
+        /// </summary>
+        public const char DEFAULT_THOUSANDS_SEPARATOR = '\'';
+
+        /// <summary>
+        /// default value for <see cref="TensSeparator"/>
+        /// </summary>
+        public const char DEFAULT_TENS_SEPARATOR = '"';
+
+        /// <summary>
+        /// default value for <see cref="AddQuoteAfterSingleChar"/>
+        /// </summary>
+        public const bool DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR = true;
+
+        /// <summary>
+        /// Should separators between thousands-groupings be included in the string that is returned
+        /// </summary>
+        public bool IncludeSeparators { get; }
+
+        /// <summary>
+        /// Value to use separating between thousands-groupings. Defaults to a single quote (')
+        /// </summary>
+        public char ThousandsSeparator { get; }
+
+        /// <summary>
+        /// Value to use separating between the tens and single digit letters. Defaults to a double quote (")
+        /// </summary>
+        public char TensSeparator { get; }
+
+        /// <summary>
+        /// <para>When the result is a single char, Should we place a single quote (true) or a double-quote (false)</para>
+        /// <para>The default is true - adding a single quote</para>
+        /// </summary>
+        public bool AddQuoteAfterSingleChar { get; }
+
+        /// <summary>
+        /// new instance of options to convert a number into its Gematria representation
+        /// </summary>
+        /// <param name="includeSeparators">Should separators between thousands-groupings be included in the string that is returned</param>
+        /// <param name="thousandsSeparator">Value to use separating between thousands-groupings. Defaults to a single quote (')</param>
+        /// <param name="tensSeparator">Value to use separating between the tens and single digit letters. Defaults to a double quote (")</param>
+        /// <param name="addQuoteAfterSingleChar">When the result is a single char, Should we place a single quote (true) or a double-quote (false)</param>
+        public GematriaOptions(bool includeSeparators = DEFAULT_SHOULD_INCLUDE_SEPARATORS,
+            char thousandsSeparator = DEFAULT_THOUSANDS_SEPARATOR,
+            char tensSeparator = DEFAULT_TENS_SEPARATOR,
+            bool addQuoteAfterSingleChar = DEFAULT_ADD_QUOTE_AFTER_SINGLE_CHAR)
+        {
+            IncludeSeparators = includeSeparators;
+            ThousandsSeparator = thousandsSeparator;
+            TensSeparator = tensSeparator;
+            AddQuoteAfterSingleChar = addQuoteAfterSingleChar;
+        }
+    }
+}


### PR DESCRIPTION
currently, ConvertToGematriaNumericString(10) is returning 

> "י

So, in these specific cases (single char when the separator is required), I've added the thousands separator - AFTER the character.
also, I've added the relevant unit-tests.

thanks.